### PR TITLE
url cookiecutter name change

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,7 +1,7 @@
 {
   "author": "<INSERT AUTHOR HERE>",
   "author_email": "<INSERT EMAIL HERE>",
-  "url": "Insert a URL here if you have one",
+  "github_url": "If you have already made a github repo to tie the project to place it here, otherwise update in setup.py later.",
   "adapter_name": "My Adapter",
   "directory_name": "{{ cookiecutter.adapter_name.lower().replace(' ','') }}",
   "project_name": "dbt-{{ cookiecutter.directory_name }}",

--- a/{{cookiecutter.project_name}}/setup.py
+++ b/{{cookiecutter.project_name}}/setup.py
@@ -13,7 +13,7 @@ setup(
     long_description=description,
     author="{{ cookiecutter.author }}",
     author_email="{{ cookiecutter.author_email }}",
-    url="{{ cookiecutter.url }}",
+    url="{{ cookiecutter.github_url }}",
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
making name of github url location more explicit and adding declaring message of where to update if not ready to add.