### PR TITLE
Fix quoting to ignore pytest warning

### DIFF
--- a/{{cookiecutter.project_name}}/pytest.ini
+++ b/{{cookiecutter.project_name}}/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 filterwarnings =
-    ignore:.*"soft_unicode" has been renamed to "soft_str"*:DeprecationWarning
+    ignore:.*'soft_unicode' has been renamed to 'soft_str'*:DeprecationWarning
     ignore:unclosed file .*:ResourceWarning
 env_files =
     test.env


### PR DESCRIPTION
The warning uses single quotes and is expressed this way in core:

https://github.com/dbt-labs/dbt-core/blob/6c8609499ae3b6603ba89b61cde4013acc937ad7/pytest.ini#L3