### PR TITLE
Fix typo in template substitution

### DIFF
--- a/{{cookiecutter.project_name}}/tox.ini
+++ b/{{cookiecutter.project_name}}/tox.ini
@@ -13,7 +13,7 @@ deps =
   -rdev-requirements.txt
   -e.
 
-[testenv:{integration,py37,py38,py39,py310,py311,py}-{{{ cookiecutter.directory_name }}}]
+[testenv:{integration,py37,py38,py39,py310,py311,py}-{ {{ cookiecutter.directory_name }} }]
 description = adapter plugin integration testing
 skip_install = true
 passenv =


### PR DESCRIPTION
As the change in tox.ini from PR #51, it makes cookiecutter  throws error when generate the  project. 