### PR TITLE
update used gh actions ahead of node12 deprecation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,12 +27,12 @@ jobs:
 
     steps:
       - name: check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -10,7 +10,7 @@ jobs:
   update-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get Latest Package Info for dbt-core
         id: package-info
         uses: dbt-labs/actions/py-package-info@v1
@@ -35,7 +35,7 @@ jobs:
           echo patch: ${{ steps.parse-valid.outputs.patch }}
 
       - name: Update project version
-        uses: jossef/action-set-json-field@v1
+        uses: jossef/action-set-json-field@v2
         with:
           file: cookiecutter.json
           field: project_version
@@ -49,7 +49,7 @@ jobs:
 
       - name: Verify Changed files
         if: ${{ !env.ACT }}
-        uses: tj-actions/verify-changed-files@v9
+        uses: tj-actions/verify-changed-files@v14
         id: verify-changed-files
         with:
           files: |
@@ -57,7 +57,7 @@ jobs:
 
       - name: Create pull request
         if: ${{ !env.ACT && steps.verify-changed-files.outputs.files_changed == 'true' }}
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v5
         with:
           title: "Bump dbt to ${{ steps.parse-valid.outputs.base-version }}"
           branch: "bump-dbt/${{ steps.parse-valid.outputs.base-version }}"

--- a/{{cookiecutter.project_name}}/.github/workflows/main.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/main.yml
@@ -43,12 +43,12 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
 
       - name: Install python dependencies
         run: |
@@ -71,12 +71,12 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 
@@ -97,7 +97,7 @@ jobs:
       - name: Check wheel contents
         run: |
           check-wheel-contents dist/*.whl --ignore W007,W008
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: dist
           path: dist/
@@ -117,7 +117,7 @@ jobs:
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -126,7 +126,7 @@ jobs:
           pip install --user --upgrade pip
           pip install --upgrade wheel
           pip --version
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
Please merge this update today! [node 12 support dropping tomorrow](https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-node12/) and these version updates to Github Actions get ahead of that. Resolves RELENG-144