### PR TITLE
get rid of duplicate 3.8 in python-version matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          python-version: [3.8, 3.8, 3.10, 3.11]
+          python-version: [3.8, 3.9, 3.10, 3.11]
 
     env:
       PYTEST_ADDOPTS: "-v --color=yes"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          python-version: [3.8, 3.9, 3.10, 3.11]
+          python-version: ['3.8', '3.9', '3.10', '3.11']
 
     env:
       PYTEST_ADDOPTS: "-v --color=yes"

--- a/{{cookiecutter.project_name}}/.github/workflows/main.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/main.yml
@@ -113,7 +113,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: [3.8, 3.9, 3.10, 3.11]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/{{cookiecutter.project_name}}/.github/workflows/main.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/main.yml
@@ -113,7 +113,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, 3.10, 3.11]
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
looking into possible failures on github action on recent update to 1.7 for version

matrix was showing two 3.8 version and on 3.10 was looking for 3.1 (see below) ignoring the zero for some reason