### PR TITLE
updating tox to not have python 3.7 in matrixes

### DIFF
--- a/{{cookiecutter.project_name}}/tox.ini
+++ b/{{cookiecutter.project_name}}/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 skipsdist = True
-envlist = py37,py38,py39,py310,py311
+envlist = py38,py39,py310,py311
 
-[testenv:{unit,py37,py38,py39,py310,py311,py}]
+[testenv:{unit,py38,py39,py310,py311,py}]
 description = unit testing
 skip_install = true
 passenv =
@@ -13,7 +13,7 @@ deps =
   -rdev-requirements.txt
   -e.
 
-[testenv:{integration,py37,py38,py39,py310,py311,py}-{ {{ cookiecutter.directory_name }} }]
+[testenv:{integration,py38,py39,py310,py311,py}-{ {{ cookiecutter.directory_name }} }]
 description = adapter plugin integration testing
 skip_install = true
 passenv =


### PR DESCRIPTION
updating tox matrix to not use python 3.7 as it was deprecated and many dependencies for github actions rely on 3.8 and up