### PR TITLE
update ref of py-package-info action to not be pointing to older versoin

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -23,14 +23,9 @@ jobs:
       - name: Check out Repo
         uses: actions/checkout@v3
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
-
       - name: Get Latest Package Info for dbt-core
         id: package-info
-        uses: dbt-labs/actions/py-package-info@v1
+        uses: dbt-labs/actions/py-package-info
         with:
           package: "dbt-core"
 

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -28,7 +28,6 @@ jobs:
         uses: dbt-labs/actions/py-package-info
         with:
           package: "dbt-core"
-          python-version: "3.8"
 
       - name: dbt-core version
         run: |

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Get Latest Package Info for dbt-core
         id: package-info
-        uses: dbt-labs/actions/py-package-info
+        uses: dbt-labs/actions/py-package-info@v1
         with:
           package: "dbt-core"
 

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -25,9 +25,10 @@ jobs:
 
       - name: Get Latest Package Info for dbt-core
         id: package-info
-        uses: dbt-labs/actions/py-package-info@v1
+        uses: dbt-labs/actions/py-package-info
         with:
           package: "dbt-core"
+          python-version: "3.8"
 
       - name: dbt-core version
         run: |
@@ -35,7 +36,7 @@ jobs:
 
       - name: Parse Semver
         id: parse-valid
-        uses: dbt-labs/actions/parse-semver
+        uses: dbt-labs/actions/parse-semver@v1
         with:
           version: ${{ steps.package-info.outputs.version }}
 

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -23,9 +23,14 @@ jobs:
       - name: Check out Repo
         uses: actions/checkout@v3
 
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+
       - name: Get Latest Package Info for dbt-core
         id: package-info
-        uses: dbt-labs/actions/py-package-info
+        uses: dbt-labs/actions/py-package-info@v1
         with:
           package: "dbt-core"
 

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Parse Semver
         id: parse-valid
-        uses: dbt-labs/actions/parse-semver@v1
+        uses: dbt-labs/actions/parse-semver
         with:
           version: ${{ steps.package-info.outputs.version }}
 

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Get Latest Package Info for dbt-core
         id: package-info
-        uses: dbt-labs/actions/py-package-info@v1
+        uses: dbt-labs/actions/py-package-info
         with:
           package: "dbt-core"
 


### PR DESCRIPTION
currently using `v1` means we look at debian10 which was using python 3.7 but after recent update we require 3.8