### PR TITLE
Revert "update ref of py-package-info action to not be pointing to older versoin"

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Get Latest Package Info for dbt-core
         id: package-info
-        uses: dbt-labs/actions/py-package-info
+        uses: dbt-labs/actions/py-package-info@v1
         with:
           package: "dbt-core"
 


### PR DESCRIPTION
Reverts dbt-labs/dbt-database-adapter-scaffold#87

merge has this comment at bottom of failing workflow run 

```
[Error: .github#L1](https://github.com/dbt-labs/dbt-database-adapter-scaffold/commit/2b6dcaf28a785e73f7c51572de36b1f480dbe033#annotation_18599730688)
the `uses' attribute must be a path, a Docker image, or owner/repo@ref
```

would like to revert the failed fix attempt, to get back to testing on the feature branch.