### PR TITLE
fix py-package-info failure cause on Check and update version action

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Get Latest Package Info for dbt-core
         id: package-info
-        uses: dbt-labs/actions/py-package-info@v1
+        uses: dbt-labs/actions/py-package-info@main
         with:
           package: "dbt-core"
 


### PR DESCRIPTION
currently using v1 means we look at debian10 which was using python 3.7 but after recent update we require 3.8

see https://github.com/dbt-labs/dbt-database-adapter-scaffold/issues/85


this pr takes place of recently reverted pr: https://github.com/dbt-labs/dbt-database-adapter-scaffold/pull/87

this action run seems to indicate fix works: https://github.com/dbt-labs/dbt-database-adapter-scaffold/actions/runs/8084753023