### PR TITLE
Fix path to the dbt-tests-adapter egg in dev-requirements.txt

### DIFF
--- a/{{cookiecutter.project_name}}/dev-requirements.txt
+++ b/{{cookiecutter.project_name}}/dev-requirements.txt
@@ -1,6 +1,6 @@
 # install latest changes in dbt-core
 git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
+git+https://github.com/dbt-labs/dbt-adapters.git#egg=dbt-tests-adapter&subdirectory=dbt-tests-adapter
 
 black==24.2.0
 bumpversion


### PR DESCRIPTION
As the adapters moved to their own
https://github.com/dbt-labs/dbt-adapters repository, we need to update the `dbt-tests-adapter` egg location.